### PR TITLE
Add support for oneOf operator

### DIFF
--- a/eppo_client/rules.py
+++ b/eppo_client/rules.py
@@ -12,6 +12,8 @@ class OperatorType(Enum):
     GT = "GT"
     LTE = "LTE"
     LT = "LT"
+    ONE_OF = "ONE_OF"
+    NOT_ONE_OF = "NOT_ONE_OF"
 
 
 class Condition(SdkBaseModel):
@@ -40,9 +42,13 @@ def matches_rule(subject_attributes: dict, rule: Rule):
 
 def evaluate_condition(subject_attributes: dict, condition: Condition) -> bool:
     subject_value = subject_attributes.get(condition.attribute, None)
-    if subject_value:
+    if subject_value is not None:
         if condition.operator == OperatorType.MATCHES:
             return bool(re.match(condition.value, str(subject_value)))
+        elif condition.operator == OperatorType.ONE_OF:
+            return str(subject_value) in condition.value
+        elif condition.operator == OperatorType.NOT_ONE_OF:
+            return str(subject_value) not in condition.value
         else:
             return isinstance(
                 subject_value, numbers.Number

--- a/test/rules_test.py
+++ b/test/rules_test.py
@@ -45,3 +45,64 @@ def test_matches_rules_true_with_numeric_value_and_regex():
     )
     rule = Rule(conditions=[condition])
     assert matches_any_rule({"age": 99}, [rule]) is True
+
+
+def test_one_of_operator_with_boolean():
+    oneOfRule = Rule(
+        conditions=[
+            Condition(operator=OperatorType.ONE_OF, value=["True"], attribute="enabled")
+        ]
+    )
+    notOneOfRule = Rule(
+        conditions=[
+            Condition(
+                operator=OperatorType.NOT_ONE_OF, value=["True"], attribute="enabled"
+            )
+        ]
+    )
+    assert matches_any_rule({"enabled": True}, [oneOfRule]) is True
+    assert matches_any_rule({"enabled": False}, [oneOfRule]) is False
+    assert matches_any_rule({"enabled": True}, [notOneOfRule]) is False
+    assert matches_any_rule({"enabled": False}, [notOneOfRule]) is True
+
+
+def test_one_of_operator_with_string():
+    oneOfRule = Rule(
+        conditions=[
+            Condition(
+                operator=OperatorType.ONE_OF, value=["john", "ron"], attribute="name"
+            )
+        ]
+    )
+    notOneOfRule = Rule(
+        conditions=[
+            Condition(operator=OperatorType.NOT_ONE_OF, value=["ron"], attribute="name")
+        ]
+    )
+    assert matches_any_rule({"name": "john"}, [oneOfRule]) is True
+    assert matches_any_rule({"name": "ron"}, [oneOfRule]) is True
+    assert matches_any_rule({"name": "sam"}, [oneOfRule]) is False
+    assert matches_any_rule({"name": "ron"}, [notOneOfRule]) is False
+    assert matches_any_rule({"name": "sam"}, [notOneOfRule]) is True
+
+
+def test_one_of_operator_with_number():
+    oneOfRule = Rule(
+        conditions=[
+            Condition(
+                operator=OperatorType.ONE_OF, value=["14", "15.11"], attribute="number"
+            )
+        ]
+    )
+    notOneOfRule = Rule(
+        conditions=[
+            Condition(
+                operator=OperatorType.NOT_ONE_OF, value=["10"], attribute="number"
+            )
+        ]
+    )
+    assert matches_any_rule({"number": "14"}, [oneOfRule]) is True
+    assert matches_any_rule({"number": 15.11}, [oneOfRule]) is True
+    assert matches_any_rule({"number": "10"}, [oneOfRule]) is False
+    assert matches_any_rule({"number": "10"}, [notOneOfRule]) is False
+    assert matches_any_rule({"number": 11}, [notOneOfRule]) is True


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)
This PR adds support for the `oneOf` and `notOneOf` targeting rule operators. These operators are important to support rule conditions such as `country is one of ('US', 'JP')`. (The same condition could be achieved with the regex `MATCHES` operator, but the `oneOf` operator is clearer.)

## Description
[//]: # (Describe your changes in detail)
Added rule evaluation logic for `oneOf` and `notOneOf`.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
Unit tests

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
