### PR TITLE
Allow assigning subject from overrides when experiment is not enabled

### DIFF
--- a/eppo_client/__init__.py
+++ b/eppo_client/__init__.py
@@ -10,7 +10,7 @@ from eppo_client.constants import MAX_CACHE_ENTRIES
 from eppo_client.http_client import HttpClient, SdkParams
 from eppo_client.read_write_lock import ReadWriteLock
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 __client: Optional[EppoClient] = None
 __lock = ReadWriteLock()

--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -20,7 +20,7 @@ class EppoClient:
     def __init__(
         self,
         config_requestor: ExperimentConfigurationRequestor,
-        assignment_logger: AssignmentLogger = AssignmentLogger(),
+        assignment_logger: AssignmentLogger,
     ):
         self.__config_requestor = config_requestor
         self.__assignment_logger = assignment_logger

--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -45,6 +45,9 @@ class EppoClient:
         validate_not_blank("subject_key", subject_key)
         validate_not_blank("experiment_key", experiment_key)
         experiment_config = self.__config_requestor.get_configuration(experiment_key)
+        override = self._get_subject_variation_override(experiment_config, subject_key)
+        if override:
+            return override
         if (
             experiment_config is None
             or not experiment_config.enabled
@@ -56,9 +59,6 @@ class EppoClient:
             )
         ):
             return None
-        override = self._get_subject_variation_override(experiment_config, subject_key)
-        if override:
-            return override
         shard = get_shard(
             "assignment-{}-{}".format(subject_key, experiment_key),
             experiment_config.subject_shards,
@@ -98,10 +98,13 @@ class EppoClient:
         self.__poller.stop()
 
     def _get_subject_variation_override(
-        self, experiment_config: ExperimentConfigurationDto, subject: str
+        self, experiment_config: Optional[ExperimentConfigurationDto], subject: str
     ) -> Optional[str]:
         subject_hash = hashlib.md5(subject.encode("utf-8")).hexdigest()
-        if subject_hash in experiment_config.overrides:
+        if (
+            experiment_config is not None
+            and subject_hash in experiment_config.overrides
+        ):
             return experiment_config.overrides[subject_hash]
         return None
 

--- a/eppo_client/config.py
+++ b/eppo_client/config.py
@@ -7,7 +7,7 @@ from eppo_client.validation import validate_not_blank
 class Config(SdkBaseModel):
     api_key: str
     base_url: str = "https://eppo.cloud/api"
-    assignment_logger: AssignmentLogger = AssignmentLogger()
+    assignment_logger: AssignmentLogger
 
     def _validate(self):
         validate_not_blank("api_key", self.api_key)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -4,6 +4,7 @@ from time import sleep
 from unittest.mock import patch
 import httpretty  # type: ignore
 import pytest
+from eppo_client.assignment_logger import AssignmentLogger
 from eppo_client.client import EppoClient
 from eppo_client.config import Config
 from eppo_client.configuration_requestor import (
@@ -43,7 +44,13 @@ def init_fixture():
         MOCK_BASE_URL + "/randomized_assignment/config",
         body=config_response_json,
     )
-    client = init(Config(base_url=MOCK_BASE_URL, api_key="dummy"))
+    client = init(
+        Config(
+            base_url=MOCK_BASE_URL,
+            api_key="dummy",
+            assignment_logger=AssignmentLogger(),
+        )
+    )
     sleep(0.1)  # wait for initialization
     yield
     client._shutdown()
@@ -52,7 +59,9 @@ def init_fixture():
 
 @patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
 def test_assign_blank_experiment(mock_config_requestor):
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     with pytest.raises(Exception) as exc_info:
         client.get_assignment("subject-1", "")
     assert exc_info.value.args[0] == "Invalid value for experiment_key: cannot be blank"
@@ -60,7 +69,9 @@ def test_assign_blank_experiment(mock_config_requestor):
 
 @patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
 def test_assign_blank_subject(mock_config_requestor):
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     with pytest.raises(Exception) as exc_info:
         client.get_assignment("", "experiment-1")
     assert exc_info.value.args[0] == "Invalid value for subject_key: cannot be blank"
@@ -78,7 +89,9 @@ def test_assign_subject_not_in_sample(mock_config_requestor):
         name="recommendation_algo",
         overrides=dict(),
     )
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     assert client.get_assignment("user-1", "experiment-key-1") is None
 
 
@@ -139,7 +152,9 @@ def test_assign_subject_with_with_attributes_and_rules(mock_config_requestor):
         overrides=dict(),
         rules=[text_rule],
     )
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     assert client.get_assignment("user-1", "experiment-key-1") is None
     assert (
         client.get_assignment(
@@ -165,7 +180,9 @@ def test_with_subject_in_overrides(mock_config_requestor):
         name="recommendation_algo",
         overrides={"d6d7705392bc7af633328bea8c4c6904": "override-variation"},
     )
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     assert client.get_assignment("user-1", "experiment-key-1") == "override-variation"
 
 
@@ -181,14 +198,18 @@ def test_with_subject_in_overrides_exp_disabled(mock_config_requestor):
         name="recommendation_algo",
         overrides={"d6d7705392bc7af633328bea8c4c6904": "override-variation"},
     )
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     assert client.get_assignment("user-1", "experiment-key-1") == "override-variation"
 
 
 @patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
 def test_with_null_experiment_config(mock_config_requestor):
     mock_config_requestor.get_configuration.return_value = None
-    client = EppoClient(config_requestor=mock_config_requestor)
+    client = EppoClient(
+        config_requestor=mock_config_requestor, assignment_logger=AssignmentLogger()
+    )
     assert client.get_assignment("user-1", "experiment-key-1") is None
 
 

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -169,6 +169,29 @@ def test_with_subject_in_overrides(mock_config_requestor):
     assert client.get_assignment("user-1", "experiment-key-1") == "override-variation"
 
 
+@patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
+def test_with_subject_in_overrides_exp_disabled(mock_config_requestor):
+    mock_config_requestor.get_configuration.return_value = ExperimentConfigurationDto(
+        subjectShards=10000,
+        percentExposure=0,
+        enabled=False,
+        variations=[
+            VariationDto(name="control", shardRange=ShardRange(start=0, end=100))
+        ],
+        name="recommendation_algo",
+        overrides={"d6d7705392bc7af633328bea8c4c6904": "override-variation"},
+    )
+    client = EppoClient(config_requestor=mock_config_requestor)
+    assert client.get_assignment("user-1", "experiment-key-1") == "override-variation"
+
+
+@patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
+def test_with_null_experiment_config(mock_config_requestor):
+    mock_config_requestor.get_configuration.return_value = None
+    client = EppoClient(config_requestor=mock_config_requestor)
+    assert client.get_assignment("user-1", "experiment-key-1") is None
+
+
 @pytest.mark.parametrize("test_case", test_data)
 def test_assign_subject_in_sample(test_case):
     print("---- Test case for {} Experiment".format(test_case["experiment"]))


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes Eppo-exp/eppo#3871
Fixes Eppo-exp/eppo#3879

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Currently, the experiment has to be enabled for the allow list to work. But the allow list should work regardless of the experiment status or traffic allocation, since it is used for QA.

## Description
[//]: # (Describe your changes in detail)

Do the allow list override check as the first part of the assignment function.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added unit test


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)

