### PR TITLE
OneOf operator should be case insensitive

### DIFF
--- a/eppo_client/__init__.py
+++ b/eppo_client/__init__.py
@@ -10,7 +10,7 @@ from eppo_client.constants import MAX_CACHE_ENTRIES
 from eppo_client.http_client import HttpClient, SdkParams
 from eppo_client.read_write_lock import ReadWriteLock
 
-__version__ = "1.0.3"
+__version__ = "1.0.4"
 
 __client: Optional[EppoClient] = None
 __lock = ReadWriteLock()

--- a/eppo_client/rules.py
+++ b/eppo_client/rules.py
@@ -46,9 +46,13 @@ def evaluate_condition(subject_attributes: dict, condition: Condition) -> bool:
         if condition.operator == OperatorType.MATCHES:
             return bool(re.match(condition.value, str(subject_value)))
         elif condition.operator == OperatorType.ONE_OF:
-            return str(subject_value) in condition.value
+            return str(subject_value).lower() in [
+                value.lower() for value in condition.value
+            ]
         elif condition.operator == OperatorType.NOT_ONE_OF:
-            return str(subject_value) not in condition.value
+            return str(subject_value).lower() not in [
+                value.lower() for value in condition.value
+            ]
         else:
             return isinstance(
                 subject_value, numbers.Number

--- a/test/rules_test.py
+++ b/test/rules_test.py
@@ -66,6 +66,32 @@ def test_one_of_operator_with_boolean():
     assert matches_any_rule({"enabled": False}, [notOneOfRule]) is True
 
 
+def test_one_of_operator_case_insensitive():
+    oneOfRule = Rule(
+        conditions=[
+            Condition(
+                operator=OperatorType.ONE_OF, value=["1Ab", "Ron"], attribute="name"
+            )
+        ]
+    )
+    assert matches_any_rule({"name": "ron"}, [oneOfRule]) is True
+    assert matches_any_rule({"name": "1AB"}, [oneOfRule]) is True
+
+
+def test_not_one_of_operator_case_insensitive():
+    notOneOf = Rule(
+        conditions=[
+            Condition(
+                operator=OperatorType.NOT_ONE_OF,
+                value=["bbB", "1.1.ab"],
+                attribute="name",
+            )
+        ]
+    )
+    assert matches_any_rule({"name": "BBB"}, [notOneOf]) is False
+    assert matches_any_rule({"name": "1.1.AB"}, [notOneOf]) is False
+
+
 def test_one_of_operator_with_string():
     oneOfRule = Rule(
         conditions=[


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes https://github.com/Eppo-exp/eppo/issues/4146

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Same changes as https://github.com/Eppo-exp/js-client-sdk/pull/6 but for Python
