### PR TITLE
Handle exceptions in polling task

### DIFF
--- a/eppo_client/__init__.py
+++ b/eppo_client/__init__.py
@@ -10,7 +10,7 @@ from eppo_client.constants import MAX_CACHE_ENTRIES
 from eppo_client.http_client import HttpClient, SdkParams
 from eppo_client.read_write_lock import ReadWriteLock
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 __client: Optional[EppoClient] = None
 __lock = ReadWriteLock()

--- a/eppo_client/configuration_requestor.py
+++ b/eppo_client/configuration_requestor.py
@@ -56,9 +56,6 @@ class ExperimentConfigurationRequestor:
                 configs[exp_key] = ExperimentConfigurationDto(**exp_config)
             self.__config_store.set_configurations(configs)
             return configs
-        except HttpRequestError as e:
-            logger.error("Error retrieving assignment configurations: " + str(e))
-            if e.is_recoverable():
-                return {}
-            else:
-                raise e  # caught by the polling task; causes assignment polling to stop
+        except Exception as e:
+            logger.error("[Test] Error retrieving assignment configurations: " + str(e))
+            return {}

--- a/eppo_client/configuration_requestor.py
+++ b/eppo_client/configuration_requestor.py
@@ -57,5 +57,5 @@ class ExperimentConfigurationRequestor:
             self.__config_store.set_configurations(configs)
             return configs
         except Exception as e:
-            logger.error("[Test] Error retrieving assignment configurations: " + str(e))
+            logger.error("Error retrieving assignment configurations: " + str(e))
             return {}

--- a/eppo_client/configuration_requestor.py
+++ b/eppo_client/configuration_requestor.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List, Optional, cast
 from eppo_client.base_model import SdkBaseModel
 from eppo_client.configuration_store import ConfigurationStore
-from eppo_client.http_client import HttpClient, HttpRequestError
+from eppo_client.http_client import HttpClient
 from eppo_client.rules import Rule
 
 from eppo_client.shard import ShardRange

--- a/eppo_client/http_client.py
+++ b/eppo_client/http_client.py
@@ -20,14 +20,6 @@ class HttpRequestError(Exception):
         self.status_code = status_code
         super().__init__(message)
 
-    def is_recoverable(self) -> bool:
-        if self.status_code >= 400 and self.status_code < 500:
-            return (
-                self.status_code == HTTPStatus.TOO_MANY_REQUESTS
-                or self.status_code == HTTPStatus.REQUEST_TIMEOUT
-            )
-        return True
-
 
 REQUEST_TIMEOUT_SECONDS = 2
 # Retry reference: https://urllib3.readthedocs.io/en/latest/reference/urllib3.util.html#module-urllib3.util.retry


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #4791

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

[See Slack thread](https://eppo-group.slack.com/archives/C035Z4W1LJZ/p1663355094784249)

## Description
[//]: # (Describe your changes in detail)

To make the SDK poller more resilient to transient failures, exceptions should not stop the polling task. 

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
