### PR TITLE
Pin Pydantic version to v1.* in setup.cfg

### DIFF
--- a/eppo_client/__init__.py
+++ b/eppo_client/__init__.py
@@ -10,7 +10,7 @@ from eppo_client.constants import MAX_CACHE_ENTRIES
 from eppo_client.http_client import HttpClient, SdkParams
 from eppo_client.read_write_lock import ReadWriteLock
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 
 __client: Optional[EppoClient] = None
 __lock = ReadWriteLock()

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,6 @@ packages = eppo_client
 python_requires = >=3.6
 include_package_data=True
 install_requires =
-    pydantic
+    pydantic<2
     requests
     cachetools


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Need to pin the Pydantic version in setup.cfg to ensure pip does not install pydantic 2 (which is currently incompatible with the SDK)

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Locally by running the package build


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
