### PR TITLE
Fix get_numeric_assignment for boolean feature flag, should return None

### DIFF
--- a/eppo_client/variation_type.py
+++ b/eppo_client/variation_type.py
@@ -16,7 +16,9 @@ class VariationType:
         if expected_variation_type == cls.STRING:
             return isinstance(assigned_variation.typedValue, str)
         elif expected_variation_type == cls.NUMERIC:
-            return isinstance(assigned_variation.typedValue, Number) and not isinstance(assigned_variation.typedValue, bool)
+            return isinstance(assigned_variation.typedValue, Number) and not isinstance(
+                assigned_variation.typedValue, bool
+            )
         elif expected_variation_type == cls.BOOLEAN:
             return isinstance(assigned_variation.typedValue, bool)
         elif expected_variation_type == cls.JSON:

--- a/eppo_client/variation_type.py
+++ b/eppo_client/variation_type.py
@@ -16,7 +16,7 @@ class VariationType:
         if expected_variation_type == cls.STRING:
             return isinstance(assigned_variation.typedValue, str)
         elif expected_variation_type == cls.NUMERIC:
-            return isinstance(assigned_variation.typedValue, Number)
+            return isinstance(assigned_variation.typedValue, Number) and not isinstance(assigned_variation.typedValue, bool)
         elif expected_variation_type == cls.BOOLEAN:
             return isinstance(assigned_variation.typedValue, bool)
         elif expected_variation_type == cls.JSON:

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -277,3 +277,11 @@ def get_assignments(test_case):
         )
         for subject in test_case.get("subjectsWithAttributes", [])
     ]
+
+@pytest.mark.parametrize("test_case", test_data)
+def test_wrong_get_typed_assignment(test_case):
+    if test_case["valueType"] == "boolean":
+        # Causes get_numeric_assignment to be used on boolean feature flag
+        test_case["valueType"] = "numeric"
+        assignments = get_assignments(test_case=test_case)
+        assert assignments == [None] * len(test_case["expectedAssignments"])

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -278,6 +278,7 @@ def get_assignments(test_case):
         for subject in test_case.get("subjectsWithAttributes", [])
     ]
 
+
 @pytest.mark.parametrize("test_case", test_data)
 def test_get_numeric_assignment_on_bool_feature_flag_should_return_none(test_case):
     if test_case["valueType"] == "boolean":

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -279,9 +279,11 @@ def get_assignments(test_case):
     ]
 
 @pytest.mark.parametrize("test_case", test_data)
-def test_wrong_get_typed_assignment(test_case):
+def test_get_numeric_assignment_on_bool_feature_flag_should_return_none(test_case):
     if test_case["valueType"] == "boolean":
-        # Causes get_numeric_assignment to be used on boolean feature flag
+        assignments = get_assignments(test_case=test_case)
+        assert assignments == test_case["expectedAssignments"]
+        # Change to get_numeric_assignment and try again
         test_case["valueType"] = "numeric"
         assignments = get_assignments(test_case=test_case)
         assert assignments == [None] * len(test_case["expectedAssignments"])


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Noticed this yesterday:

<img width="764" alt="Screenshot 2023-09-28 at 3 09 07 PM" src="https://github.com/Eppo-exp/python-sdk/assets/2822951/a9efe267-cb97-4807-9f48-5b8d6158fad6">

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
