### PR TITLE
add try except to all public client methods (FF-947)

### DIFF
--- a/eppo_client/__init__.py
+++ b/eppo_client/__init__.py
@@ -38,6 +38,7 @@ def init(config: Config) -> EppoClient:
         http_client=http_client, config_store=config_store
     )
     assignment_logger = config.assignment_logger
+    is_graceful_mode = config.is_graceful_mode
     global __client
     global __lock
     try:
@@ -48,6 +49,7 @@ def init(config: Config) -> EppoClient:
         __client = EppoClient(
             config_requestor=config_requestor,
             assignment_logger=assignment_logger,
+            is_graceful_mode=is_graceful_mode,
         )
         return __client
     finally:

--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -25,9 +25,11 @@ class EppoClient:
         self,
         config_requestor: ExperimentConfigurationRequestor,
         assignment_logger: AssignmentLogger,
+        is_graceful_mode: bool = True,
     ):
         self.__config_requestor = config_requestor
         self.__assignment_logger = assignment_logger
+        self.__is_graceful_mode = is_graceful_mode
         self.__poller = Poller(
             interval_millis=POLL_INTERVAL_MILLIS,
             jitter_millis=POLL_JITTER_MILLIS,
@@ -38,62 +40,92 @@ class EppoClient:
     def get_string_assignment(
         self, subject_key: str, flag_key: str, subject_attributes=dict()
     ) -> Optional[str]:
-        assigned_variation = self.get_assignment_variation(
-            subject_key, flag_key, subject_attributes, VariationType.STRING
-        )
-        return (
-            assigned_variation.typed_value
-            if assigned_variation is not None
-            else assigned_variation
-        )
+        try:
+            assigned_variation = self.get_assignment_variation(
+                subject_key, flag_key, subject_attributes, VariationType.STRING
+            )
+            return (
+                assigned_variation.typed_value
+                if assigned_variation is not None
+                else assigned_variation
+            )
+        except Exception as e:
+            if self.__is_graceful_mode:
+                logger.error("[Eppo SDK] Error getting assignment: " + str(e))
+                return None
+            raise e
 
     def get_numeric_assignment(
         self, subject_key: str, flag_key: str, subject_attributes=dict()
     ) -> Optional[Number]:
-        assigned_variation = self.get_assignment_variation(
-            subject_key, flag_key, subject_attributes, VariationType.NUMERIC
-        )
-        return (
-            assigned_variation.typed_value
-            if assigned_variation is not None
-            else assigned_variation
-        )
+        try:
+            assigned_variation = self.get_assignment_variation(
+                subject_key, flag_key, subject_attributes, VariationType.NUMERIC
+            )
+            return (
+                assigned_variation.typed_value
+                if assigned_variation is not None
+                else assigned_variation
+            )
+        except Exception as e:
+            if self.__is_graceful_mode:
+                logger.error("[Eppo SDK] Error getting assignment: " + str(e))
+                return None
+            raise e
 
     def get_boolean_assignment(
         self, subject_key: str, flag_key: str, subject_attributes=dict()
     ) -> Optional[bool]:
-        assigned_variation = self.get_assignment_variation(
-            subject_key, flag_key, subject_attributes, VariationType.BOOLEAN
-        )
-        return (
-            assigned_variation.typed_value
-            if assigned_variation is not None
-            else assigned_variation
-        )
+        try:
+            assigned_variation = self.get_assignment_variation(
+                subject_key, flag_key, subject_attributes, VariationType.BOOLEAN
+            )
+            return (
+                assigned_variation.typed_value
+                if assigned_variation is not None
+                else assigned_variation
+            )
+        except Exception as e:
+            if self.__is_graceful_mode:
+                logger.error("[Eppo SDK] Error getting assignment: " + str(e))
+                return None
+            raise e
 
     def get_parsed_json_assignment(
         self, subject_key: str, flag_key: str, subject_attributes=dict()
     ) -> Optional[Dict[Any, Any]]:
-        assigned_variation = self.get_assignment_variation(
-            subject_key, flag_key, subject_attributes, VariationType.JSON
-        )
-        return (
-            assigned_variation.typed_value
-            if assigned_variation is not None
-            else assigned_variation
-        )
+        try:
+            assigned_variation = self.get_assignment_variation(
+                subject_key, flag_key, subject_attributes, VariationType.JSON
+            )
+            return (
+                assigned_variation.typed_value
+                if assigned_variation is not None
+                else assigned_variation
+            )
+        except Exception as e:
+            if self.__is_graceful_mode:
+                logger.error("[Eppo SDK] Error getting assignment: " + str(e))
+                return None
+            raise e
 
     def get_json_string_assignment(
         self, subject_key: str, flag_key: str, subject_attributes=dict()
     ) -> Optional[str]:
-        assigned_variation = self.get_assignment_variation(
-            subject_key, flag_key, subject_attributes, VariationType.JSON
-        )
-        return (
-            assigned_variation.value
-            if assigned_variation is not None
-            else assigned_variation
-        )
+        try:
+            assigned_variation = self.get_assignment_variation(
+                subject_key, flag_key, subject_attributes, VariationType.JSON
+            )
+            return (
+                assigned_variation.value
+                if assigned_variation is not None
+                else assigned_variation
+            )
+        except Exception as e:
+            if self.__is_graceful_mode:
+                logger.error("[Eppo SDK] Error getting assignment: " + str(e))
+                return None
+            raise e
 
     @deprecated(
         "get_assignment is deprecated in favor of the typed get_<type>_assignment methods"
@@ -101,14 +133,23 @@ class EppoClient:
     def get_assignment(
         self, subject_key: str, flag_key: str, subject_attributes=dict()
     ) -> Optional[str]:
-        assigned_variation = self.get_assignment_variation(
-            subject_key, flag_key, subject_attributes
-        )
-        return (
-            assigned_variation.value
-            if assigned_variation is not None
-            else assigned_variation
-        )
+        try:
+            assigned_variation = self.get_assignment_variation(
+                subject_key, flag_key, subject_attributes
+            )
+            return (
+                assigned_variation.value
+                if assigned_variation is not None
+                else assigned_variation
+            )
+        except ValueError as e:
+            # allow ValueError to bubble up as it is a validation error
+            raise e
+        except Exception as e:
+            if self.__is_graceful_mode:
+                logger.error("[Eppo SDK] Error getting assignment: " + str(e))
+                return None
+            raise e
 
     def get_assignment_variation(
         self,

--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -49,6 +49,9 @@ class EppoClient:
                 if assigned_variation is not None
                 else assigned_variation
             )
+        except ValueError as e:
+            # allow ValueError to bubble up as it is a validation error
+            raise e
         except Exception as e:
             if self.__is_graceful_mode:
                 logger.error("[Eppo SDK] Error getting assignment: " + str(e))
@@ -67,6 +70,9 @@ class EppoClient:
                 if assigned_variation is not None
                 else assigned_variation
             )
+        except ValueError as e:
+            # allow ValueError to bubble up as it is a validation error
+            raise e
         except Exception as e:
             if self.__is_graceful_mode:
                 logger.error("[Eppo SDK] Error getting assignment: " + str(e))
@@ -85,6 +91,9 @@ class EppoClient:
                 if assigned_variation is not None
                 else assigned_variation
             )
+        except ValueError as e:
+            # allow ValueError to bubble up as it is a validation error
+            raise e
         except Exception as e:
             if self.__is_graceful_mode:
                 logger.error("[Eppo SDK] Error getting assignment: " + str(e))
@@ -103,6 +112,9 @@ class EppoClient:
                 if assigned_variation is not None
                 else assigned_variation
             )
+        except ValueError as e:
+            # allow ValueError to bubble up as it is a validation error
+            raise e
         except Exception as e:
             if self.__is_graceful_mode:
                 logger.error("[Eppo SDK] Error getting assignment: " + str(e))
@@ -121,6 +133,9 @@ class EppoClient:
                 if assigned_variation is not None
                 else assigned_variation
             )
+        except ValueError as e:
+            # allow ValueError to bubble up as it is a validation error
+            raise e
         except Exception as e:
             if self.__is_graceful_mode:
                 logger.error("[Eppo SDK] Error getting assignment: " + str(e))

--- a/eppo_client/config.py
+++ b/eppo_client/config.py
@@ -8,6 +8,7 @@ class Config(SdkBaseModel):
     api_key: str
     base_url: str = "https://fscdn.eppo.cloud/api"
     assignment_logger: AssignmentLogger
+    is_graceful_mode: bool = True
 
     def _validate(self):
         validate_not_blank("api_key", self.api_key)

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -252,6 +252,37 @@ def test_with_null_experiment_config(mock_config_requestor):
     assert client.get_assignment("user-1", "experiment-key-1") is None
 
 
+@patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
+@patch.object(EppoClient, "get_assignment_variation")
+def test_graceful_mode_on(mock_get_assignment_variation, mock_config_requestor):
+    mock_get_assignment_variation.side_effect = Exception("This is a mock exception!")
+
+    client = EppoClient(
+        config_requestor=mock_config_requestor,
+        assignment_logger=AssignmentLogger(),
+        is_graceful_mode=True,
+    )
+
+    res = client.get_assignment("user-1", "experiment-key-1")
+    mock_get_assignment_variation.assert_called_once()
+    assert res is None
+
+
+@patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
+@patch.object(EppoClient, "get_assignment_variation")
+def test_graceful_mode_off(mock_get_assignment_variation, mock_config_requestor):
+    mock_get_assignment_variation.side_effect = Exception("This is a mock exception!")
+
+    client = EppoClient(
+        config_requestor=mock_config_requestor,
+        assignment_logger=AssignmentLogger(),
+        is_graceful_mode=False,
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        client.get_assignment("user-1", "experiment-key-1")
+
+
 @pytest.mark.parametrize("test_case", test_data)
 def test_assign_subject_in_sample(test_case):
     print("---- Test case for {} Experiment".format(test_case["experiment"]))

--- a/test/client_test.py
+++ b/test/client_test.py
@@ -263,9 +263,12 @@ def test_graceful_mode_on(mock_get_assignment_variation, mock_config_requestor):
         is_graceful_mode=True,
     )
 
-    res = client.get_assignment("user-1", "experiment-key-1")
-    mock_get_assignment_variation.assert_called_once()
-    assert res is None
+    assert client.get_assignment("user-1", "experiment-key-1") is None
+    assert client.get_boolean_assignment("user-1", "experiment-key-1") is None
+    assert client.get_json_string_assignment("user-1", "experiment-key-1") is None
+    assert client.get_numeric_assignment("user-1", "experiment-key-1") is None
+    assert client.get_string_assignment("user-1", "experiment-key-1") is None
+    assert client.get_parsed_json_assignment("user-1", "experiment-key-1") is None
 
 
 @patch("eppo_client.configuration_requestor.ExperimentConfigurationRequestor")
@@ -279,8 +282,13 @@ def test_graceful_mode_off(mock_get_assignment_variation, mock_config_requestor)
         is_graceful_mode=False,
     )
 
-    with pytest.raises(Exception) as exc_info:
+    with pytest.raises(Exception):
         client.get_assignment("user-1", "experiment-key-1")
+        client.get_boolean_assignment("user-1", "experiment-key-1")
+        client.get_json_string_assignment("user-1", "experiment-key-1")
+        client.get_numeric_assignment("user-1", "experiment-key-1")
+        client.get_string_assignment("user-1", "experiment-key-1")
+        client.get_parsed_json_assignment("user-1", "experiment-key-1")
 
 
 @pytest.mark.parametrize("test_case", test_data)


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Add protection for exceptions in our SDKs from bubbling out to our customers' applications by wrapping all public methods in a try/catch.

## Description
[//]: # (Describe your changes in detail)

* `is_graceful_mode` is on by default - this is prevent exceptions, expect for `ValueError` from bubbling up as this is the way python performs validation. we throw this exception if the `flagKey` is not set in `validate_not_blank`
* Add tests for mode on and off

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
