### PR TITLE
[UFC] Clear config store before loading new config

### DIFF
--- a/eppo_client/configuration_store.py
+++ b/eppo_client/configuration_store.py
@@ -23,6 +23,7 @@ class ConfigurationStore(Generic[T]):
     def set_configurations(self, configs: Dict[str, T]):
         try:
             self.__lock.acquire_write()
+            self.__cache.clear()
             for key, config in configs.items():
                 self.__cache[key] = config
         finally:

--- a/test/configuration_store_test.py
+++ b/test/configuration_store_test.py
@@ -37,3 +37,16 @@ def test_evicts_old_entries_when_max_size_exceeded():
     assert (
         store.get_configuration("test-entry-{}".format(TEST_MAX_SIZE - 1)) == mock_flag
     )
+
+
+def test_evicts_old_entries_when_setting_new_flags():
+    store: ConfigurationStore[str] = ConfigurationStore(max_size=TEST_MAX_SIZE)
+
+    store.set_configurations({"flag": mock_flag, "second_flag": mock_flag})
+    assert store.get_configuration("flag") == mock_flag
+    assert store.get_configuration("second_flag") == mock_flag
+
+    # Updating the flags should evict flags that no longer exist
+    store.set_configurations({"flag": mock_flag})
+    assert store.get_configuration("flag") == mock_flag
+    assert store.get_configuration("second_flag") is None


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #ff-1989

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

We need to ensure flags that are no longer in the config are removed when updating the configuration

## Description
[//]: # (Describe your changes in detail)

Clear the configuration store before loading new flags

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added a unit test


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
