### PR TITLE
backporting fix to stale configuration cache to `v1.x.y` branch

### DIFF
--- a/eppo_client/__init__.py
+++ b/eppo_client/__init__.py
@@ -10,7 +10,7 @@ from eppo_client.constants import MAX_CACHE_ENTRIES
 from eppo_client.http_client import HttpClient, SdkParams
 from eppo_client.read_write_lock import ReadWriteLock
 
-__version__ = "1.3.1"
+__version__ = "1.3.2"
 
 __client: Optional[EppoClient] = None
 __lock = ReadWriteLock()

--- a/eppo_client/configuration_store.py
+++ b/eppo_client/configuration_store.py
@@ -23,6 +23,7 @@ class ConfigurationStore(Generic[T]):
     def set_configurations(self, configs: Dict[str, T]):
         try:
             self.__lock.acquire_write()
+            self.__cache.clear()
             for key, config in configs.items():
                 self.__cache[key] = config
         finally:

--- a/test/configuration_store_test.py
+++ b/test/configuration_store_test.py
@@ -39,3 +39,16 @@ def test_evicts_old_entries_when_max_size_exceeded():
     assert (
         store.get_configuration("test-entry-{}".format(TEST_MAX_SIZE - 1)) == test_exp
     )
+
+
+def test_evicts_old_entries_when_setting_new_flags():
+    store: ConfigurationStore[str] = ConfigurationStore(max_size=TEST_MAX_SIZE)
+
+    store.set_configurations({"flag": mock_flag, "second_flag": mock_flag})
+    assert store.get_configuration("flag") == mock_flag
+    assert store.get_configuration("second_flag") == mock_flag
+
+    # Updating the flags should evict flags that no longer exist
+    store.set_configurations({"flag": mock_flag})
+    assert store.get_configuration("flag") == mock_flag
+    assert store.get_configuration("second_flag") is None

--- a/test/configuration_store_test.py
+++ b/test/configuration_store_test.py
@@ -44,11 +44,11 @@ def test_evicts_old_entries_when_max_size_exceeded():
 def test_evicts_old_entries_when_setting_new_flags():
     store: ConfigurationStore[str] = ConfigurationStore(max_size=TEST_MAX_SIZE)
 
-    store.set_configurations({"flag": mock_flag, "second_flag": mock_flag})
-    assert store.get_configuration("flag") == mock_flag
-    assert store.get_configuration("second_flag") == mock_flag
+    store.set_configurations({"flag": test_exp, "second_flag": test_exp})
+    assert store.get_configuration("flag") == test_exp
+    assert store.get_configuration("second_flag") == test_exp
 
     # Updating the flags should evict flags that no longer exist
-    store.set_configurations({"flag": mock_flag})
-    assert store.get_configuration("flag") == mock_flag
+    store.set_configurations({"flag": test_exp})
+    assert store.get_configuration("flag") == test_exp
     assert store.get_configuration("second_flag") is None


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

A bug was fixed in the `3.x.y` branch (https://github.com/Eppo-exp/python-sdk/pull/39/commits/435e7f0e19f6c7cd4497a8c641f61052b9205281) but is effecting customers in the `1.x.y` branch. We need to make a new release at `1.x.y` to make it available for those not ready to upgrade to 3.

## Description
[//]: # (Describe your changes in detail)

Create a new release branch:

```
➜  python-sdk git:(heads/main) git checkout -b release/1.3.2 v1.3.1
Switched to a new branch 'release/1.3.2'
```

We will publish from this branch and it is the base of this PR.

Created a branch from it and cherry-picked the changes + version bump:

```
➜  python-sdk git:(release/1.3.2) git checkout -b cherry-pick-d663582ccabd34ec66785b1ef2c6c2709fe67300
Switched to a new branch 'cherry-pick-d663582ccabd34ec66785b1ef2c6c2709fe67300'
➜  python-sdk git:(cherry-pick-d663582ccabd34ec66785b1ef2c6c2709fe67300) git cherry-pick d663582ccabd34ec66785b1ef2c6c2709fe67300
Auto-merging eppo_client/configuration_store.py
Auto-merging test/configuration_store_test.py
[cherry-pick-d663582ccabd34ec66785b1ef2c6c2709fe67300 435e7f0] clear config store before loading new config (#30)
 Author: Sven Schmit <sven@geteppo.com>
 Date: Thu Apr 25 15:23:26 2024 -0700
 2 files changed, 14 insertions(+)
```

## Next steps

Our github action is built to publish from `main` so I will perform a manual publish according to our run book.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)


[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
