### PR TITLE
Upgrade to latest github packages to fix publish command. (#41)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: Install pypa/build
@@ -26,7 +26,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: python-package-distributions
           path: dist/*
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: python-package-distributions
           path: dist/
@@ -67,12 +67,12 @@ jobs:
 
     steps:
     - name: Download all the dists
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v1.2.3
+      uses: sigstore/gh-action-sigstore-python@v2.1.1
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

* github actions deprecated

<img width="1114" alt="Screenshot 2024-05-23 at 1 53 49 PM" src="https://github.com/Eppo-exp/python-sdk/assets/57361/7472c613-3eb0-49d7-9170-f629c98133e4">

* signing package failing: https://github.com/Eppo-exp/python-sdk/actions/runs/9214277452/job/25350163988

## Description
[//]: # (Describe your changes in detail)

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Publish `1.3.3` successfully, including signing: https://github.com/Eppo-exp/python-sdk/actions/runs/9214669277

<img width="1207" alt="Screenshot 2024-05-23 at 1 50 56 PM" src="https://github.com/Eppo-exp/python-sdk/assets/57361/1b4b5d48-7d30-4290-80e9-afcf6c162c85">

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
