### PR TITLE
Added semver dependency

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,3 +23,4 @@ install_requires =
     pydantic-settings
     requests
     cachetools
+    semver


### PR DESCRIPTION
---
labels: bugfix
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: N/A. Can create an issue if needed.

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Whenever I install the new SDK into a fresh Python environment, I encounter the error `ModuleNotFoundError: No module named 'semver'` whenever running `import eppo_client`. Running a `pip install semver` fixes the issue`. 

## Description
[//]: # (Describe your changes in detail)
Just added `semver` to the `install_requires` list. 

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
I created a fresh Python virtual environment and installed from this branch with `pip install git+https://github.com/Eppo-exp/python-sdk.git@tyler/add-semver-dependency`. After doing that, I can run `import eppo_client` without errors.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
