### PR TITLE
remove unneeded print statement

### DIFF
--- a/eppo_client/configuration_requestor.py
+++ b/eppo_client/configuration_requestor.py
@@ -66,7 +66,6 @@ class ExperimentConfigurationRequestor:
 
             if flag_data.get("bandits", {}):
                 bandit_data = self.fetch_bandits()
-                print(bandit_data)
                 self.store_bandits(bandit_data)
             self.__is_initialized = True
         except Exception as e:


### PR DESCRIPTION
Noticed an extra print statement that we don't need. Removing it