### PR TITLE
[ufc] to_string: handle integers explicitly for better performance

### DIFF
--- a/eppo_client/rules.py
+++ b/eppo_client/rules.py
@@ -130,4 +130,6 @@ def to_string(value: AttributeType) -> str:
         return "true" if value else "false"
     elif isinstance(value, float):
         return f"{value:.0f}" if value.is_integer() else str(value)
+    elif isinstance(value, int):
+        return str(value)
     return json.dumps(value)


### PR DESCRIPTION


## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

`json.dumps` is slow, and integers can be common, so convert them using `str` instead for better performance

## Description
[//]: # (Describe your changes in detail)

in to_string, add an explicit conversion for integers

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

tests still pass

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
