### PR TITLE
[ff-2397] Allow attributes to be specified as dicts

### DIFF
--- a/eppo_client/bandit.py
+++ b/eppo_client/bandit.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import logging
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from eppo_client.models import (
     BanditCategoricalAttributeCoefficient,
@@ -8,7 +8,9 @@ from eppo_client.models import (
     BanditModelData,
     BanditNumericAttributeCoefficient,
 )
+from eppo_client.rules import to_string
 from eppo_client.sharders import Sharder
+from eppo_client.types import AttributesDict
 
 
 logger = logging.getLogger(__name__)
@@ -25,10 +27,41 @@ class Attributes:
 
     @classmethod
     def empty(cls):
+        """
+        Create an empty Attributes instance with no numeric or categorical attributes.
+
+        Returns:
+            Attributes: An instance of the Attributes class with empty dictionaries for numeric and categorical attributes.
+        """
         return cls({}, {})
+
+    @classmethod
+    def from_dict(cls, attributes: AttributesDict):
+        """
+        Create an Attributes instance from a dictionary of attributes.
+
+        Args:
+            attributes (Dict[str, Union[float, int, bool, str]]): A dictionary where keys are attribute names
+            and values are attribute values which can be of type float, int, bool, or str.
+
+        Returns:
+            Attributes: An instance of the Attributes class with numeric and categorical attributes separated.
+        """
+        numeric_attributes = {
+            key: float(value)
+            for key, value in attributes.items()
+            if isinstance(value, (int, float))
+        }
+        categorical_attributes = {
+            key: to_string(value)
+            for key, value in attributes.items()
+            if isinstance(value, (str, bool))
+        }
+        return cls(numeric_attributes, categorical_attributes)
 
 
 ActionContexts = Dict[str, Attributes]
+ActionContextsDict = Dict[str, AttributesDict]
 
 
 @dataclass

--- a/eppo_client/bandit.py
+++ b/eppo_client/bandit.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 import logging
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional
 
 from eppo_client.models import (
     BanditCategoricalAttributeCoefficient,
@@ -31,7 +31,8 @@ class Attributes:
         Create an empty Attributes instance with no numeric or categorical attributes.
 
         Returns:
-            Attributes: An instance of the Attributes class with empty dictionaries for numeric and categorical attributes.
+            Attributes: An instance of the Attributes class with empty dictionaries
+                for numeric and categorical attributes.
         """
         return cls({}, {})
 

--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -310,7 +310,11 @@ class EppoClient:
         # get experiment assignment
         # ignoring type because Dict[str, str] satisfies Dict[str, str | ...] but mypy does not understand
         variation = self.get_string_assignment(
-            flag_key, subject_key, subject_attributes.categorical_attributes | subject_attributes.numeric_attributes, default  # type: ignore
+            flag_key,
+            subject_key,
+            subject_attributes.categorical_attributes
+            | subject_attributes.numeric_attributes,  # type: ignore
+            default,
         )
 
         # if the variation is not the bandit key, then the subject is not allocated in the bandit

--- a/eppo_client/eval.py
+++ b/eppo_client/eval.py
@@ -5,7 +5,7 @@ from eppo_client.rules import matches_rule
 from dataclasses import dataclass
 import datetime
 
-from eppo_client.types import SubjectAttributes
+from eppo_client.types import AttributesDict
 
 
 @dataclass
@@ -13,7 +13,7 @@ class FlagEvaluation:
     flag_key: str
     variation_type: VariationType
     subject_key: str
-    subject_attributes: SubjectAttributes
+    subject_attributes: AttributesDict
     allocation_key: Optional[str]
     variation: Optional[Variation]
     extra_logging: Dict[str, str]
@@ -28,7 +28,7 @@ class Evaluator:
         self,
         flag: Flag,
         subject_key: str,
-        subject_attributes: SubjectAttributes,
+        subject_attributes: AttributesDict,
     ) -> FlagEvaluation:
         if not flag.enabled:
             return none_result(
@@ -93,7 +93,7 @@ def none_result(
     flag_key: str,
     variation_type: VariationType,
     subject_key: str,
-    subject_attributes: SubjectAttributes,
+    subject_attributes: AttributesDict,
 ) -> FlagEvaluation:
     return FlagEvaluation(
         flag_key=flag_key,

--- a/eppo_client/rules.py
+++ b/eppo_client/rules.py
@@ -7,7 +7,7 @@ from typing import Any, List
 import semver
 
 from eppo_client.models import SdkBaseModel
-from eppo_client.types import AttributeType, ConditionValueType, SubjectAttributes
+from eppo_client.types import AttributeType, ConditionValueType, AttributesDict
 
 
 class OperatorType(Enum):
@@ -32,7 +32,7 @@ class Rule(SdkBaseModel):
     conditions: List[Condition]
 
 
-def matches_rule(rule: Rule, subject_attributes: SubjectAttributes) -> bool:
+def matches_rule(rule: Rule, subject_attributes: AttributesDict) -> bool:
     return all(
         evaluate_condition(condition, subject_attributes)
         for condition in rule.conditions
@@ -40,7 +40,7 @@ def matches_rule(rule: Rule, subject_attributes: SubjectAttributes) -> bool:
 
 
 def evaluate_condition(
-    condition: Condition, subject_attributes: SubjectAttributes
+    condition: Condition, subject_attributes: AttributesDict
 ) -> bool:
     subject_value = subject_attributes.get(condition.attribute, None)
     if condition.operator == OperatorType.IS_NULL:

--- a/eppo_client/types.py
+++ b/eppo_client/types.py
@@ -3,5 +3,5 @@ from typing import Dict, List, Union
 ValueType = Union[str, int, float, bool]
 AttributeType = Union[str, int, float, bool, None]
 ConditionValueType = Union[AttributeType, List[AttributeType]]
-SubjectAttributes = Dict[str, AttributeType]
+AttributesDict = Dict[str, AttributeType]
 Action = str

--- a/test/client_bandit_test.py
+++ b/test/client_bandit_test.py
@@ -71,6 +71,7 @@ def init_fixture():
             base_url=MOCK_BASE_URL,
             api_key="dummy",
             assignment_logger=mock_assignment_logger,
+            is_graceful_mode=False,
         )
     )
     sleep(0.1)  # wait for initialization
@@ -91,7 +92,7 @@ def test_get_bandit_action_bandit_does_not_exist():
         "nonexistent_bandit",
         "subject_key",
         DEFAULT_SUBJECT_ATTRIBUTES,
-        [],
+        {},
         "default_variation",
     )
     assert result == BanditResult("default_variation", None)
@@ -100,7 +101,7 @@ def test_get_bandit_action_bandit_does_not_exist():
 def test_get_bandit_action_flag_without_bandit():
     client = get_instance()
     result = client.get_bandit_action(
-        "a_flag", "subject_key", DEFAULT_SUBJECT_ATTRIBUTES, [], "default_variation"
+        "a_flag", "subject_key", DEFAULT_SUBJECT_ATTRIBUTES, {}, "default_variation"
     )
     assert result == BanditResult("default_variation", None)
 


### PR DESCRIPTION

[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #ff-2397

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Currently, users need to specify numerical and categorical attributes explicitly. This adds an option to supply a dictionary and we do the conversion to numerical and categorical attributes within the SDK based on value types

## Description
[//]: # (Describe your changes in detail)

- Allow users to give subject and action attributes as dicts
- If needed, convert these dicts to attributes
- Changed the types for this pattern to look clean
- Turn off graceful mode for tests to catch errors explicitly

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

All tests pass

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
