### PR TITLE
bug: [Consolidate publishing and signing distributions into one step]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
+      and Sign with Sigstore
     if: startsWith(github.ref, 'refs/tags/')
     needs:
     - build
@@ -43,6 +44,7 @@ jobs:
       url: https://pypi.org/p/eppo-server-sdk
     permissions:
       id-token: write
+      contents: write
 
     steps:
       - name: Download all the dists
@@ -52,46 +54,15 @@ jobs:
           path: dist/
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-
-  github-release:
-    name: >-
-      Sign the Python 🐍 distribution 📦 with Sigstore
-      and upload them to GitHub Release
-    needs:
-    - publish-to-pypi
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write
-      id-token: write
-
-    steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
-      with:
-        name: python-package-distributions
-        path: dist/
-    - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
-      with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-    - name: Create GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      run: >-
-        gh release create
-        '${{ github.ref_name }}'
-        --repo '${{ github.repository }}'
-        --notes ""
-    - name: Upload artifact signatures to GitHub Release
-      env:
-        GITHUB_TOKEN: ${{ github.token }}
-      # Upload to GitHub Release using the `gh` CLI.
-      # `dist/` contains the built packages, and the
-      # sigstore-produced signatures and certificates.
-      run: >-
-        gh release upload
-        '${{ github.ref_name }}' dist/**
-        --repo '${{ github.repository }}'
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v2.1.1
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: Update GitHub Release and Upload Artifacts
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          gh release edit '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes ""
+          gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,8 @@
 name: Publish to PyPi
 
 on:
-  push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -60,9 +58,3 @@ jobs:
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl
-      - name: Update GitHub Release and Upload Artifacts
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          gh release edit '${{ github.ref_name }}' --repo '${{ github.repository }}' --notes ""
-          gh release upload '${{ github.ref_name }}' dist/** --repo '${{ github.repository }}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to PyPi
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -129,3 +129,7 @@ response = JSONResponse(content={"flagConfigurations": flag_config_json})
 ## Philosophy
 
 Eppo's SDKs are built for simplicity, speed and reliability. Flag configurations are compressed and distributed over a global CDN (Fastly), typically reaching your servers in under 15ms. Server SDKs continue polling Eppo’s API at 30-second intervals. Configurations are then cached locally, ensuring that each assignment is made instantly. Evaluation logic within each SDK consists of a few lines of simple numeric and string comparisons. The typed functions listed above are all developers need to understand, abstracting away the complexity of the Eppo's underlying (and expanding) feature set.
+
+## Contributing
+
+To publish a new version of the SDK, set the version as desired in `eppo_client/version.py`, then create a new Github release. The CI/CD configuration will handle the build and publish to PyPi.


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

Publish with signing fails because at that step the release has already been made; it attempts to create another one: https://github.com/Eppo-exp/python-sdk/actions/runs/9945729712/job/27474683642

This seems to only happen to me because I'm used to creating a Github release like in the other SDKs. If just pushing to a tag without a release the process likely works.

## Description
[//]: # (Describe your changes in detail)

* Combine the two publishing steps (publishing and publishing with signing) into one.
* Add readme for developers.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Difficult to test: suggestions welcome but we might need to iterate on it.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
