### PR TITLE
fix: Use action key to select best scoring action

### DIFF
--- a/eppo_client/bandit.py
+++ b/eppo_client/bandit.py
@@ -160,11 +160,11 @@ class BanditEvaluator:
         self, action_scores, gamma, probability_floor
     ) -> Dict[str, float]:
         number_of_actions = len(action_scores)
-	# Find the max score
+        # Find the max score
         best_score = max(action_scores.values())
-	# Get all the keys that have the same best score (if there's more than one)
-        best_action_keys = [k for k,v in action_scores.items() if v == best_score]
-	# Get the lowest lexicographically ordered key.
+        # Get all the keys that have the same best score (if there's more than one)
+        best_action_keys = [k for k, v in action_scores.items() if v == best_score]
+        # Get the lowest lexicographically ordered key.
         best_action = min(best_action_keys)
 
         # adjust probability floor for number of actions to control the sum

--- a/eppo_client/bandit.py
+++ b/eppo_client/bandit.py
@@ -160,8 +160,12 @@ class BanditEvaluator:
         self, action_scores, gamma, probability_floor
     ) -> Dict[str, float]:
         number_of_actions = len(action_scores)
-        best_action = max(action_scores, key=action_scores.get)
-        best_score = action_scores[best_action]
+	# Find the max score
+        best_score = max(action_scores.values())
+	# Get all the keys that have the same best score (if there's more than one)
+        best_action_keys = [k for k,v in action_scores.items() if v == best_score]
+	# Get the lowest lexicographically ordered key.
+        best_action = min(best_action_keys)
 
         # adjust probability floor for number of actions to control the sum
         min_probability = probability_floor / number_of_actions


### PR DESCRIPTION
🎟️ Fixes: FF-3060
👯 Universal Test PR: [sdk-test-data/52](https://github.com/Eppo-exp/sdk-test-data/pull/52)

## Motivation and Context
Tie-breaker by action name was introduced to the bandit evaluation algorithm to eliminate ambiguity when multiple actions are the top scoring

## Description
- Selects top scoring action by score then by action key

## How has this been tested?
Universal tests