### PR TITLE
Bump version patch #

### DIFF
--- a/eppo_client/version.py
+++ b/eppo_client/version.py
@@ -1,4 +1,4 @@
 # Note to developers: When ready to bump to 4.0, please change
 # the `POLL_INTERVAL_SECONDS` constant in `eppo_client/constants.py`
 # to 30 seconds to match the behavior of the other server SDKs.
-__version__ = "3.5.1"
+__version__ = "3.5.2"


### PR DESCRIPTION
bump to v3.5.2 to pick up high-score tie-breaking.