### PR TITLE
fix: add timezone to timestamps

### DIFF
--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -222,7 +222,7 @@ class EppoClient:
             "featureFlag": flag_key,
             "variation": result.variation.key if result and result.variation else None,
             "subject": subject_key,
-            "timestamp": datetime.datetime.utcnow().isoformat(),
+            "timestamp": _utcnow().isoformat(),
             "subjectAttributes": subject_attributes,
             "metaData": {"sdkLanguage": "python", "sdkVersion": __version__},
         }
@@ -370,7 +370,7 @@ class EppoClient:
                 "modelVersion": (
                     bandit_data.bandit_model_version if evaluation else None
                 ),
-                "timestamp": datetime.datetime.utcnow().isoformat(),
+                "timestamp": _utcnow().isoformat(),
                 "subjectNumericAttributes": (
                     subject_context_attributes.numeric_attributes
                     if evaluation.subject_attributes
@@ -492,3 +492,7 @@ def convert_actions_to_action_contexts(
     actions: Union[ActionContexts, ActionAttributes]
 ) -> ActionContexts:
     return {k: convert_attributes_to_context_attributes(v) for k, v in actions.items()}
+
+
+def _utcnow() -> datetime.datetime:
+    return datetime.datetime.now(datetime.timezone.utc)

--- a/eppo_client/version.py
+++ b/eppo_client/version.py
@@ -1,4 +1,4 @@
 # Note to developers: When ready to bump to 4.0, please change
 # the `POLL_INTERVAL_SECONDS` constant in `eppo_client/constants.py`
 # to 30 seconds to match the behavior of the other server SDKs.
-__version__ = "3.5.1"
+__version__ = "3.5.2"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

This fixes timestamps, so they get properly serialized with timezone information.

## Description
[//]: # (Describe your changes in detail)

```
>>> datetime.datetime.now(datetime.timezone.utc).isoformat()
'2024-08-20T17:58:45.374349+00:00'
>>> datetime.datetime.utcnow().isoformat()
'2024-08-20T18:01:31.482134'
```

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
Not tested.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
