### PR TITLE
fix: `|` on dicts is only available with Python-3.9+

### DIFF
--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -469,7 +469,7 @@ def convert_context_attributes_to_attributes(
         return subject_context
 
     # ignoring type because Dict[str, str] satisfies Dict[str, str | ...] but mypy does not understand
-    return subject_context.numeric_attributes | subject_context.categorical_attributes  # type: ignore
+    return {**subject_context.numeric_attributes, **subject_context.categorical_attributes}  # type: ignore
 
 
 def convert_attributes_to_context_attributes(

--- a/eppo_client/version.py
+++ b/eppo_client/version.py
@@ -1,4 +1,4 @@
 # Note to developers: When ready to bump to 4.0, please change
 # the `POLL_INTERVAL_SECONDS` constant in `eppo_client/constants.py`
 # to 30 seconds to match the behavior of the other server SDKs.
-__version__ = "3.5.2"
+__version__ = "3.5.3"


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: #__issue__

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)
`|` on dicts is only available with Python-3.9+. Using Python-3.8 or lower, tests fail

## Description
[//]: # (Describe your changes in detail)
Replace `|` with unpacking.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)
Run tests with Python 3.8.3

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
