### PR TITLE
FF-3143 feat: add caching logger for assignment and bandit events

### DIFF
--- a/eppo_client/assignment_logger.py
+++ b/eppo_client/assignment_logger.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional, Tuple, MutableMapping
 
 
 class AssignmentLogger:
@@ -7,3 +7,53 @@ class AssignmentLogger:
 
     def log_bandit_action(self, bandit_event: Dict):
         pass
+
+
+class AssignmentCacheLogger(AssignmentLogger):
+    def __init__(
+        self,
+        inner: AssignmentLogger,
+        *,
+        assignment_cache: Optional[MutableMapping] = None,
+        bandit_cache: Optional[MutableMapping] = None,
+    ):
+        self.__inner = inner
+        self.__assignment_cache = assignment_cache
+        self.__bandit_cache = bandit_cache
+
+    def log_assignment(self, event: Dict):
+        _cache_or_call(
+            self.__assignment_cache,
+            *AssignmentCacheLogger.__assignment_cache_keyvalue(event),
+            lambda: self.__inner.log_assignment(event),
+        )
+
+    def log_bandit_action(self, event: Dict):
+        _cache_or_call(
+            self.__bandit_cache,
+            *AssignmentCacheLogger.__bandit_cache_keyvalue(event),
+            lambda: self.__inner.log_bandit_action(event),
+        )
+
+    @staticmethod
+    def __assignment_cache_keyvalue(event: Dict) -> Tuple[Tuple, Tuple]:
+        key = (event["featureFlag"], event["subject"])
+        value = (event["allocation"], event["variation"])
+        return key, value
+
+    @staticmethod
+    def __bandit_cache_keyvalue(event: Dict) -> Tuple[Tuple, Tuple]:
+        key = (event["flagKey"], event["subject"])
+        value = (event["banditKey"], event["action"])
+        return key, value
+
+
+def _cache_or_call(cache: Optional[MutableMapping], key, value, fn):
+    if cache is not None and (previous := cache.get(key)) and previous == value:
+        # ok, cached
+        return
+
+    fn()
+
+    if cache is not None:
+        cache[key] = value

--- a/eppo_client/assignment_logger.py
+++ b/eppo_client/assignment_logger.py
@@ -1,11 +1,7 @@
 from typing import Dict
-from eppo_client.base_model import BaseModel
-from pydantic import ConfigDict
 
 
-class AssignmentLogger(BaseModel):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
+class AssignmentLogger:
     def log_assignment(self, assignment_event: Dict):
         pass
 

--- a/eppo_client/client.py
+++ b/eppo_client/client.py
@@ -364,12 +364,10 @@ class EppoClient:
                 "flagKey": flag_key,
                 "banditKey": bandit_data.bandit_key,
                 "subject": subject_key,
-                "action": evaluation.action_key if evaluation else None,
-                "actionProbability": evaluation.action_weight if evaluation else None,
-                "optimalityGap": evaluation.optimality_gap if evaluation else None,
-                "modelVersion": (
-                    bandit_data.bandit_model_version if evaluation else None
-                ),
+                "action": evaluation.action_key,
+                "actionProbability": evaluation.action_weight,
+                "optimalityGap": evaluation.optimality_gap,
+                "modelVersion": (bandit_data.bandit_model_version),
                 "timestamp": _utcnow().isoformat(),
                 "subjectNumericAttributes": (
                     subject_context_attributes.numeric_attributes

--- a/eppo_client/config.py
+++ b/eppo_client/config.py
@@ -1,3 +1,5 @@
+from pydantic import Field, ConfigDict
+
 from eppo_client.assignment_logger import AssignmentLogger
 from eppo_client.base_model import SdkBaseModel
 from eppo_client.validation import validate_not_blank
@@ -8,9 +10,14 @@ from eppo_client.constants import (
 
 
 class Config(SdkBaseModel):
+    model_config = ConfigDict(
+        # AssignmentLogger is not a pydantic model
+        arbitrary_types_allowed=True
+    )
+
     api_key: str
     base_url: str = "https://fscdn.eppo.cloud/api"
-    assignment_logger: AssignmentLogger
+    assignment_logger: AssignmentLogger = Field(exclude=True)
     is_graceful_mode: bool = True
     poll_interval_seconds: int = POLL_INTERVAL_SECONDS_DEFAULT
     poll_jitter_seconds: int = POLL_JITTER_SECONDS_DEFAULT

--- a/eppo_client/version.py
+++ b/eppo_client/version.py
@@ -1,4 +1,4 @@
 # Note to developers: When ready to bump to 4.0, please change
 # the `POLL_INTERVAL_SECONDS` constant in `eppo_client/constants.py`
 # to 30 seconds to match the behavior of the other server SDKs.
-__version__ = "3.5.4"
+__version__ = "3.6.0"

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,5 @@ pytest
 pytest-mock
 mypy
 httpretty
+cachetools
+types-cachetools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,5 @@
 pydantic==2.4.*
 pydantic-settings==2.0.*
 requests==2.31.*
-cachetools==5.3.*
-types-cachetools==5.3.*
 types-requests==2.31.*
 semver==3.0.*

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,4 @@ install_requires =
     pydantic
     pydantic-settings
     requests
-    cachetools
     semver

--- a/test/cache_assignment_logger_test.py
+++ b/test/cache_assignment_logger_test.py
@@ -11,10 +11,10 @@ def test_non_caching():
     inner = Mock()
     logger = AssignmentCacheLogger(inner)
 
-    logger.log_assignment(mk_assignment_event())
-    logger.log_assignment(mk_assignment_event())
-    logger.log_bandit_action(mk_bandit_event())
-    logger.log_bandit_action(mk_bandit_event())
+    logger.log_assignment(make_assignment_event())
+    logger.log_assignment(make_assignment_event())
+    logger.log_bandit_action(make_bandit_event())
+    logger.log_bandit_action(make_bandit_event())
 
     assert inner.log_assignment.call_count == 2
     assert inner.log_bandit_action.call_count == 2
@@ -24,8 +24,8 @@ def test_assignment_cache():
     inner = Mock()
     logger = AssignmentCacheLogger(inner, assignment_cache=LRUCache(100))
 
-    logger.log_assignment(mk_assignment_event())
-    logger.log_assignment(mk_assignment_event())
+    logger.log_assignment(make_assignment_event())
+    logger.log_assignment(make_assignment_event())
 
     assert inner.log_assignment.call_count == 1
 
@@ -34,8 +34,8 @@ def test_bandit_cache():
     inner = Mock()
     logger = AssignmentCacheLogger(inner, bandit_cache=LRUCache(100))
 
-    logger.log_bandit_action(mk_bandit_event())
-    logger.log_bandit_action(mk_bandit_event())
+    logger.log_bandit_action(make_bandit_event())
+    logger.log_bandit_action(make_bandit_event())
 
     assert inner.log_bandit_action.call_count == 1
 
@@ -44,18 +44,18 @@ def test_bandit_flip_flop():
     inner = Mock()
     logger = AssignmentCacheLogger(inner, bandit_cache=LRUCache(100))
 
-    logger.log_bandit_action(mk_bandit_event(action="action1"))
-    logger.log_bandit_action(mk_bandit_event(action="action1"))
+    logger.log_bandit_action(make_bandit_event(action="action1"))
+    logger.log_bandit_action(make_bandit_event(action="action1"))
     assert inner.log_bandit_action.call_count == 1
 
-    logger.log_bandit_action(mk_bandit_event(action="action2"))
+    logger.log_bandit_action(make_bandit_event(action="action2"))
     assert inner.log_bandit_action.call_count == 2
 
-    logger.log_bandit_action(mk_bandit_event(action="action1"))
+    logger.log_bandit_action(make_bandit_event(action="action1"))
     assert inner.log_bandit_action.call_count == 3
 
 
-def mk_assignment_event(
+def make_assignment_event(
     *,
     allocation="allocation",
     experiment="experiment",
@@ -80,7 +80,7 @@ def mk_assignment_event(
     }
 
 
-def mk_bandit_event(
+def make_bandit_event(
     *,
     flag_key="flagKey",
     bandit_key="banditKey",

--- a/test/cache_assignment_logger_test.py
+++ b/test/cache_assignment_logger_test.py
@@ -1,0 +1,112 @@
+from unittest.mock import Mock
+
+from cachetools import LRUCache
+
+from eppo_client.assignment_logger import AssignmentCacheLogger
+from eppo_client.client import _utcnow
+from eppo_client.version import __version__
+
+
+def test_non_caching():
+    inner = Mock()
+    logger = AssignmentCacheLogger(inner)
+
+    logger.log_assignment(mk_assignment_event())
+    logger.log_assignment(mk_assignment_event())
+    logger.log_bandit_action(mk_bandit_event())
+    logger.log_bandit_action(mk_bandit_event())
+
+    assert inner.log_assignment.call_count == 2
+    assert inner.log_bandit_action.call_count == 2
+
+
+def test_assignment_cache():
+    inner = Mock()
+    logger = AssignmentCacheLogger(inner, assignment_cache=LRUCache(100))
+
+    logger.log_assignment(mk_assignment_event())
+    logger.log_assignment(mk_assignment_event())
+
+    assert inner.log_assignment.call_count == 1
+
+
+def test_bandit_cache():
+    inner = Mock()
+    logger = AssignmentCacheLogger(inner, bandit_cache=LRUCache(100))
+
+    logger.log_bandit_action(mk_bandit_event())
+    logger.log_bandit_action(mk_bandit_event())
+
+    assert inner.log_bandit_action.call_count == 1
+
+
+def test_bandit_flip_flop():
+    inner = Mock()
+    logger = AssignmentCacheLogger(inner, bandit_cache=LRUCache(100))
+
+    logger.log_bandit_action(mk_bandit_event(action="action1"))
+    logger.log_bandit_action(mk_bandit_event(action="action1"))
+    assert inner.log_bandit_action.call_count == 1
+
+    logger.log_bandit_action(mk_bandit_event(action="action2"))
+    assert inner.log_bandit_action.call_count == 2
+
+    logger.log_bandit_action(mk_bandit_event(action="action1"))
+    assert inner.log_bandit_action.call_count == 3
+
+
+def mk_assignment_event(
+    *,
+    allocation="allocation",
+    experiment="experiment",
+    featureFlag="featureFlag",
+    variation="variation",
+    subject="subject",
+    timestamp=_utcnow().isoformat(),
+    subjectAttributes={},
+    metaData={"sdkLanguage": "python", "sdkVersion": __version__},
+    extra_logging={},
+):
+    return {
+        **extra_logging,
+        "allocation": allocation,
+        "experiment": experiment,
+        "featureFlag": featureFlag,
+        "variation": variation,
+        "subject": subject,
+        "timestamp": timestamp,
+        "subjectAttributes": subjectAttributes,
+        "metaData": metaData,
+    }
+
+
+def mk_bandit_event(
+    *,
+    flag_key="flagKey",
+    bandit_key="banditKey",
+    subject_key="subjectKey",
+    action="action",
+    action_probability=1.0,
+    optimality_gap=None,
+    evaluation=None,
+    bandit_data=None,
+    subject_context_attributes=None,
+    timestamp=_utcnow().isoformat(),
+    model_version="model_version",
+    meta_data={"sdkLanguage": "python", "sdkVersion": __version__},
+):
+    return {
+        "flagKey": flag_key,
+        "banditKey": bandit_key,
+        "subject": subject_key,
+        "action": action,
+        "actionProbability": action_probability,
+        "optimalityGap": optimality_gap,
+        "modelVersion": model_version,
+        "timestamp": timestamp,
+        "subjectNumericAttributes": {},
+        "subjectCategoricalAttributes": {},
+        "actionNumericAttributes": {},
+        "actionCategoricalAttributes": {},
+        "metaData": meta_data,
+    }


### PR DESCRIPTION
---
labels: mergeable
---
[//]: #  (Link to the issue corresponding to this chunk of work)
Fixes: https://linear.app/eppo/issue/FF-3143/%5Bpython%5D-deduplication-cache-for-assignment-and-bandit-events

## Motivation and Context
[//]: #  (Why is this change required? What problem does it solve?)

This allows deduplicating assignments and bandit actions before they are logged to client storage.

## Description
[//]: # (Describe your changes in detail)

This PR adds a caching logger adapter that optionally accepts caches for assignment and bandit. Cache implementation can be any `MutableMapping`:
- Any instance of `Cache` from `cachetools` (with any configuration)
- `dict` for non-evicting (unbound) cache (not recommended)

If cache is not provided for assignment or bandits, that type of events is not cached.

This design decouples eppoclient completely from caching implementation and the user may use any of the great caching implementation out there that fit their needs.

## How has this been tested?
[//]: # (Please describe in detail how you tested your changes)

Added new test cases.

[//]: # (OPTIONAL)
[//]: # (Add one or multiple labels: enhancement, refactoring, bugfix)
